### PR TITLE
Add user management service routes and update Swagger UI configuration

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,15 +11,22 @@ spring.cloud.gateway.routes[0].id=gtu-route-management-service
 spring.cloud.gateway.routes[0].uri=lb://gtu-route-management-service
 spring.cloud.gateway.routes[0].predicates[0]=Path=/api/route-management/**
 spring.cloud.gateway.routes[0].filters[0]=RewritePath=/api/route-management/(?<segment>.*), /$\{segment}
-
+# User service
+spring.cloud.gateway.routes[1].id=gtu-users-management-service
+spring.cloud.gateway.routes[1].uri=lb://gtu-users-management-service
+spring.cloud.gateway.routes[1].predicates[0]=Path=/api/user/**
+spring.cloud.gateway.routes[1].filters[0]=RewritePath=/api/user/(?<segment>.*), /$\{segment}
 
 # Swagger UI
 springdoc.swagger-ui.enabled=true
 springdoc.swagger-ui.path=/swagger-ui.html
 springdoc.api-docs.enabled=true
+# Swagger UI - Route Management
 springdoc.swagger-ui.urls[0].name=Route Management
 springdoc.swagger-ui.urls[0].url=/api/route-management/v3/api-docs
-
+# Swagger UI - User Service
+springdoc.swagger-ui.urls[1].name=User Service
+springdoc.swagger-ui.urls[1].url=/api/user/v3/api-docs
 
 
 


### PR DESCRIPTION
This pull request includes updates to the `application.properties` file to add routing and Swagger UI configuration for the User Management Service.

Routing configuration:

* Added routing for the User Management Service with ID `gtu-users-management-service`, URI `lb://gtu-users-management-service`, and path predicate `/api/user/**`.

Swagger UI configuration:

* Added Swagger UI configuration for the User Management Service with the name "User Service" and URL `/api/user/v3/api-docs`.