### PR TITLE
Add websocket route for driver-tracker service

### DIFF
--- a/src/main/java/com/gtu/api_gateway/config/RouteConfig.java
+++ b/src/main/java/com/gtu/api_gateway/config/RouteConfig.java
@@ -56,6 +56,9 @@ public class RouteConfig {
                     .rewritePath("/api/driver-tracker/(?<segment>.*)", SEGM_STRING)
                 )
                 .uri("lb://gtu-driver-tracker"))
+            .route("driver-tracker-websocket", r -> r
+                .path("/ws/tracking")
+                .uri("lb://gtu-driver-tracker"))
             .build();
     }
 }


### PR DESCRIPTION
This pull request adds a new route configuration to the API Gateway. The change introduces a WebSocket route for driver tracking.

Routing updates:

* [`src/main/java/com/gtu/api_gateway/config/RouteConfig.java`](diffhunk://#diff-8caae11e88a117dff4e5e1b217ed878f4bc0ad52352c0a270595f1bf92eda4c0R59-R61): Added a new route with the ID `driver-tracker-websocket` to handle WebSocket connections at the `/ws/tracking` path, forwarding them to the `gtu-driver-tracker` service.