### PR TITLE
Feature/websocket route

### DIFF
--- a/src/main/java/com/gtu/api_gateway/config/RouteConfig.java
+++ b/src/main/java/com/gtu/api_gateway/config/RouteConfig.java
@@ -57,7 +57,7 @@ public class RouteConfig {
                 )
                 .uri("lb://gtu-driver-tracker"))
             .route("driver-tracker-websocket", r -> r
-                .path("/ws/tracking")
+                .path("/ws/tracking/**")
                 .uri("lb://gtu-driver-tracker"))
             .build();
     }

--- a/src/main/java/com/gtu/api_gateway/config/RouteConfig.java
+++ b/src/main/java/com/gtu/api_gateway/config/RouteConfig.java
@@ -59,6 +59,6 @@ public class RouteConfig {
             .route("driver-tracker-websocket", r -> r
                 .path("/ws/tracking/**")
                 .uri("lb://gtu-driver-tracker"))
-            .build();
+        .build();
     }
 }


### PR DESCRIPTION
This pull request includes a small but important change to the routing configuration in the `RouteConfig` class. The change updates the path for the `driver-tracker-websocket` route to allow wildcard matching.

* [`src/main/java/com/gtu/api_gateway/config/RouteConfig.java`](diffhunk://#diff-8caae11e88a117dff4e5e1b217ed878f4bc0ad52352c0a270595f1bf92eda4c0L60-R60): Modified the `driver-tracker-websocket` route path from `/ws/tracking` to `/ws/tracking/**` to enable matching of subpaths under `/ws/tracking`.